### PR TITLE
Switch to App Store and Play Store badges

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -289,3 +289,20 @@ body {
 .swiping-is-cool {
   height: 300px;
 }
+
+/**
+ * App Store Buttons
+ */
+
+.app-store-btn {
+  display: inline-block;
+  overflow: hidden;
+  background: url(https://linkmaker.itunes.apple.com/en-gb/badge-lrg.svg?releaseDate=2019-04-11&kind=iossoftware&bubble=ios_apps) no-repeat;
+  width: 135px;
+  height: 40px;
+}
+
+.play-store-btn > img {
+  width: 155px;
+  margin: -10px;
+}

--- a/index.html
+++ b/index.html
@@ -48,9 +48,8 @@
                 </button>
               </div>
               <div class="flex-grid__box flex-grid__box--gutters">
-                <button class="button button--purple">
-                  Download from Play Store
-                </button>
+                <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
+                </a>
               </div>
             </div>
           </div>
@@ -81,9 +80,8 @@
                     </button>
                   </div>
                   <div class="flex-grid__box flex-grid__box--gutters">
-                    <button class="button button--purple">
-                      Download from Play Store
-                    </button>
+                    <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
+                    </a>
                   </div>
                 </div>
               </div>
@@ -108,9 +106,8 @@
                     </button>
                   </div>
                   <div class="flex-grid__box flex-grid__box--gutters">
-                    <button class="button button--purple">
-                      Download from Play Store
-                    </button>
+                    <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
+                    </a>
                   </div>
                 </div>
               </div>
@@ -137,9 +134,8 @@
               </button>
             </div>
             <div class="flex-grid__box flex-grid__box--gutters">
-              <button class="button button--purple">
-                Download from Play Store
-              </button>
+              <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
+              </a>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -43,9 +43,8 @@
             </div>
             <div class="flex-grid flex-grid--rows">
               <div class="flex-grid__box flex-grid__box--gutters">
-                <button class="button button--blue">
-                  Download from App Store
-                </button>
+                <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" style="display:inline-block;overflow:hidden;background:url(https://linkmaker.itunes.apple.com/en-gb/badge-lrg.svg?releaseDate=2019-04-11&kind=iossoftware&bubble=ios_apps) no-repeat;width:135px;height:40px;">
+                </a>
               </div>
               <div class="flex-grid__box flex-grid__box--gutters">
                 <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
@@ -75,9 +74,8 @@
                 </p>
                 <div class="flex-grid flex-grid--rows">
                   <div class="flex-grid__box flex-grid__box--gutters">
-                    <button class="button button--blue">
-                      Download from App Store
-                    </button>
+                    <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" style="display:inline-block;overflow:hidden;background:url(https://linkmaker.itunes.apple.com/en-gb/badge-lrg.svg?releaseDate=2019-04-11&kind=iossoftware&bubble=ios_apps) no-repeat;width:135px;height:40px;">
+                    </a>
                   </div>
                   <div class="flex-grid__box flex-grid__box--gutters">
                     <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
@@ -101,9 +99,8 @@
                 </p>
                 <div class="flex-grid flex-grid--rows">
                   <div class="flex-grid__box flex-grid__box--gutters">
-                    <button class="button button--blue">
-                      Download from App Store
-                    </button>
+                    <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" style="display:inline-block;overflow:hidden;background:url(https://linkmaker.itunes.apple.com/en-gb/badge-lrg.svg?releaseDate=2019-04-11&kind=iossoftware&bubble=ios_apps) no-repeat;width:135px;height:40px;">
+                    </a>
                   </div>
                   <div class="flex-grid__box flex-grid__box--gutters">
                     <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
@@ -129,9 +126,8 @@
           </h2>
           <div class="flex-grid flex-grid--rows">
             <div class="flex-grid__box flex-grid__box--gutters">
-              <button class="button button--blue">
-                Download from App Store
-              </button>
+              <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" style="display:inline-block;overflow:hidden;background:url(https://linkmaker.itunes.apple.com/en-gb/badge-lrg.svg?releaseDate=2019-04-11&kind=iossoftware&bubble=ios_apps) no-repeat;width:135px;height:40px;">
+              </a>
             </div>
             <div class="flex-grid__box flex-grid__box--gutters">
               <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>

--- a/index.html
+++ b/index.html
@@ -1,156 +1,171 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Sitrus Moods</title>
-    <link href="https://fonts.googleapis.com/css?family=Fredoka+One|Nunito:400,400i,700,700i" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="css/reset.css" />
-    <link rel="stylesheet" type="text/css" href="css/style.css" />
-    <link rel="stylesheet" type="text/css" href="css/mobile.css" />
-  </head>
-  <body>
 
-    <div class="main">
-      <div class="header">
-        <div class="header__section">
-          <div class="header__logo">
-              <img class="header__logo__img" src="images/logo-small-white.png" />
-              <span class="header__logo__text">Sitrus Mood</span>
-          </div>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sitrus Moods</title>
+  <link href="https://fonts.googleapis.com/css?family=Fredoka+One|Nunito:400,400i,700,700i" rel="stylesheet">
+  <link rel="stylesheet" type="text/css" href="css/reset.css" />
+  <link rel="stylesheet" type="text/css" href="css/style.css" />
+  <link rel="stylesheet" type="text/css" href="css/mobile.css" />
+</head>
+
+<body>
+
+  <div class="main">
+    <div class="header">
+      <div class="header__section">
+        <div class="header__logo">
+          <img class="header__logo__img" src="images/logo-small-white.png" />
+          <span class="header__logo__text">Sitrus Mood</span>
         </div>
-        <div class="header__section">
-          <nav class="header__nav">
-            <!--
+      </div>
+      <div class="header__section">
+        <nav class="header__nav">
+          <!--
             <a href="#" class="header__nav__item">About</a>
             <a href="#" class="header__nav__item">Contact</a>
             -->
-          </nav>
+        </nav>
+      </div>
+    </div>
+
+    <div class="splash">
+      <div class="splash__image"></div>
+      <div class="splash__content flex-grid flex-grid--columns container">
+        <div class="flex-grid__box flex-grid__box--2">
+          <img class="splash__logo" src="images/logo-large-white.png" />
+          <div class="splash__text">
+            <h1 class="splash__title">
+              Mood Tracking Made Easy
+            </h1>
+            <h3 class="splash__subtitle">
+              Track and measure your mood with daily quizzes.
+            </h3>
+          </div>
+          <div class="flex-grid flex-grid--rows">
+            <div class="flex-grid__box flex-grid__box--gutters">
+              <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" target="_blank"
+                class="app-store-btn">
+              </a>
+            </div>
+            <div class="flex-grid__box flex-grid__box--gutters">
+              <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'
+                class="play-store-btn" target="_blank"><img alt='Get it on Google Play'
+                  src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' style="" />
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="flex-grid__box flex-grid__box--1">
+          <img class="splash__screenshot twistable" src="images/tracking-screen.png" />
         </div>
       </div>
+    </div>
 
-      <div class="splash">
-        <div class="splash__image"></div>
-        <div class="splash__content flex-grid flex-grid--columns container">
-          <div class="flex-grid__box flex-grid__box--2">
-            <img class="splash__logo" src="images/logo-large-white.png" />
-            <div class="splash__text">
-              <h1 class="splash__title">
-                Mood Tracking Made Easy
-              </h1>
-              <h3 class="splash__subtitle">
-                Track and measure your mood with daily quizzes.
-              </h3>
-            </div>
-            <div class="flex-grid flex-grid--rows">
-              <div class="flex-grid__box flex-grid__box--gutters">
-                <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" style="display:inline-block;overflow:hidden;background:url(https://linkmaker.itunes.apple.com/en-gb/badge-lrg.svg?releaseDate=2019-04-11&kind=iossoftware&bubble=ios_apps) no-repeat;width:135px;height:40px;">
-                </a>
+    <div class="hero hero--blue">
+      <div class="container">
+        <div class="flex-grid flex-grid--columns">
+          <div class="flex-grid__box flex-grid__box--1">
+            <!-- <img class="swiping-is-cool" src="images/swiping-is-cool.gif" /> -->
+            <img class="swiping-is-cool" src="images/happy-screen.png" />
+            <img class="swiping-is-cool" src="images/swiping-screen.png" />
+          </div>
+          <div class="flex-grid__box flex-grid__box--2 flex-grid flex-grid--columns flex-grid--align-center">
+            <div class="hero__content hero__content--right flex-grid__box flex-grid__box--1">
+              <h2 class="hero__title">Quick and Simple Quizzes</h2>
+              <p class="hero__subtitle">
+                Swipe yes or no to track, measure, and reflect on different aspects of your mood.
+              </p>
+              <div class="flex-grid flex-grid--rows">
+                <div class="flex-grid__box flex-grid__box--gutters">
+                  <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" target="_blank"
+                    class="app-store-btn">
+                  </a>
+                </div>
+                <div class="flex-grid__box flex-grid__box--gutters">
+                  <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'
+                    class="play-store-btn" target="_blank"><img alt='Get it on Google Play'
+                      src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' />
+                  </a>
+                </div>
               </div>
-              <div class="flex-grid__box flex-grid__box--gutters">
-                <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
-                </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="hero hero--purple">
+      <div class="container">
+        <div class="flex-grid flex-grid--columns">
+          <div class="flex-grid__box flex-grid__box--2 flex-grid flex-grid--columns flex-grid--align-center">
+            <div class="hero__content flex-grid__box flex-grid__box--1">
+              <h2 class="hero__title">Look Back on Your Past Moods</h2>
+              <p class="hero__subtitle">
+                Scroll through your mood over time to keep an eye on your mental health.
+              </p>
+              <div class="flex-grid flex-grid--rows">
+                <div class="flex-grid__box flex-grid__box--gutters">
+                  <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" target="_blank"
+                    class="app-store-btn">
+                  </a>
+                </div>
+                <div class="flex-grid__box flex-grid__box--gutters">
+                  <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'
+                    class="play-store-btn" target="_blank"><img alt='Get it on Google Play'
+                      src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' />
+                  </a>
+                </div>
               </div>
             </div>
           </div>
           <div class="flex-grid__box flex-grid__box--1">
-            <img class="splash__screenshot twistable" src="images/tracking-screen.png" />
+            <img class="swiping-is-cool" src="images/score-screen.png" />
+            <img class="swiping-is-cool" src="images/history-screen.png" />
           </div>
         </div>
       </div>
+    </div>
 
-      <div class="hero hero--blue">
-        <div class="container">
-          <div class="flex-grid flex-grid--columns">
-            <div class="flex-grid__box flex-grid__box--1">
-              <!-- <img class="swiping-is-cool" src="images/swiping-is-cool.gif" /> -->
-              <img class="swiping-is-cool" src="images/happy-screen.png" />
-              <img class="swiping-is-cool" src="images/swiping-screen.png" />
-            </div>
-            <div class="flex-grid__box flex-grid__box--2 flex-grid flex-grid--columns flex-grid--align-center">
-              <div class="hero__content hero__content--right flex-grid__box flex-grid__box--1">
-                <h2 class="hero__title">Quick and Simple Quizzes</h2>
-                <p class="hero__subtitle">
-                  Swipe yes or no to track, measure, and reflect on different aspects of your mood.
-                </p>
-                <div class="flex-grid flex-grid--rows">
-                  <div class="flex-grid__box flex-grid__box--gutters">
-                    <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" style="display:inline-block;overflow:hidden;background:url(https://linkmaker.itunes.apple.com/en-gb/badge-lrg.svg?releaseDate=2019-04-11&kind=iossoftware&bubble=ios_apps) no-repeat;width:135px;height:40px;">
-                    </a>
-                  </div>
-                  <div class="flex-grid__box flex-grid__box--gutters">
-                    <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
+    <div class="hero hero--centered">
+      <div class="container">
+        <h2 class="hero__title">
+          Life can be sweet. Life can be sour.
+          <br />
+          How are you feeling today?
+        </h2>
+        <div class="flex-grid flex-grid--rows">
+          <div class="flex-grid__box flex-grid__box--gutters">
+            <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" target="_blank"
+              class="app-store-btn">
+            </a>
+          </div>
+          <div class="flex-grid__box flex-grid__box--gutters">
+            <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'
+              class="play-store-btn" target="_blank"><img alt='Get it on Google Play'
+                src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' />
+            </a>
           </div>
         </div>
       </div>
+    </div>
 
-      <div class="hero hero--purple">
-        <div class="container">
-          <div class="flex-grid flex-grid--columns">
-            <div class="flex-grid__box flex-grid__box--2 flex-grid flex-grid--columns flex-grid--align-center">
-              <div class="hero__content flex-grid__box flex-grid__box--1">
-                <h2 class="hero__title">Look Back on Your Past Moods</h2>
-                <p class="hero__subtitle">
-                  Scroll through your mood over time to keep an eye on your mental health.
-                </p>
-                <div class="flex-grid flex-grid--rows">
-                  <div class="flex-grid__box flex-grid__box--gutters">
-                    <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" style="display:inline-block;overflow:hidden;background:url(https://linkmaker.itunes.apple.com/en-gb/badge-lrg.svg?releaseDate=2019-04-11&kind=iossoftware&bubble=ios_apps) no-repeat;width:135px;height:40px;">
-                    </a>
-                  </div>
-                  <div class="flex-grid__box flex-grid__box--gutters">
-                    <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="flex-grid__box flex-grid__box--1">
-              <img class="swiping-is-cool" src="images/score-screen.png" />
-              <img class="swiping-is-cool" src="images/history-screen.png" />
-            </div>
-          </div>
-        </div>
+    <div class="footer">
+      <div class="footer__logo">
+        <img class="footer__logo__image" src="images/logo-large-white.png" />
+        <span class="footer__logo__text">Sitrus</span>
       </div>
-
-      <div class="hero hero--centered">
-        <div class="container">
-          <h2 class="hero__title">
-            Life can be sweet. Life can be sour.
-            <br />
-            How are you feeling today?
-          </h2>
-          <div class="flex-grid flex-grid--rows">
-            <div class="flex-grid__box flex-grid__box--gutters">
-              <a href="https://itunes.apple.com/us/app/sitrus-moods/id1454172167?mt=8" style="display:inline-block;overflow:hidden;background:url(https://linkmaker.itunes.apple.com/en-gb/badge-lrg.svg?releaseDate=2019-04-11&kind=iossoftware&bubble=ios_apps) no-repeat;width:135px;height:40px;">
-              </a>
-            </div>
-            <div class="flex-grid__box flex-grid__box--gutters">
-              <a href='https://play.google.com/store/apps/details?id=io.sitrus.moodSwipes&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="footer">
-        <div class="footer__logo">
-          <img class="footer__logo__image" src="images/logo-large-white.png" />
-          <span class="footer__logo__text">Sitrus</span>
-        </div>
-        <nav class="footer__nav">
-          <!--
+      <nav class="footer__nav">
+        <!--
           <a class="footer__nav__item" href="#">About Us</a>
           <a class="footer__nav__item" href="#">Contact Us</a>
           -->
-          <a class="footer__nav__item" href="privacy_policy.html">Privacy Policy</a>
-        </nav>
-      </div>
+        <a class="footer__nav__item" href="privacy_policy.html">Privacy Policy</a>
+      </nav>
     </div>
-    <script src="js/main.js"></script>
-  </body>
+  </div>
+  <script src="js/main.js"></script>
+</body>
+
 </html>


### PR DESCRIPTION
This is intended as a solution to #3. It replaces the buttons "Download from the App Store" and "Download from the Play Store" with the relevant badges from Apple and Google's marketing guidelines respectively.

However, when I just checked, the sizing of the Google Play Store badge appears to be significantly off, so this is not ready to merge yet.